### PR TITLE
Feat/serialport operate

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "build-prod": "tsc --project ./tsconfig.json",
         "build": "npm run build-prod",
         "build-and-publish": "tsc --build && npm publish",
-        "test": "jest"
+        "ci-test": "jest"
     },
     "repository": {
         "type": "git",

--- a/src/index.ts
+++ b/src/index.ts
@@ -106,6 +106,12 @@ export class RemoteSerialportServer extends AbsRemoteSerialServer<RemoteSerialSe
         this.io = new SocketServer(socket_server_options);
     }
 
+    /**
+     * @description
+     * After RemoteSerialportSocket Return the Serial Port Path, Validate the Serial Port Path
+     * @param serialport_path - serial port path
+     * @param rule - regular expression to validate the serial port path
+     */
     static serialport_path_validate(serialport_path: string, rule: string | RegExp = /^(\/dev\/tty(USB|AMA|ACM)|COM)[0-9]+$/): boolean {
         return serialport_path_validate(serialport_path, rule);
     }


### PR DESCRIPTION
- use event emitter proxy export port instance
  - read data-chunk
  - write buffer
- add RemoteSerialportSocket broken status ( maybe use event driven on next step?)
